### PR TITLE
docs: remove RB3 Gen2 references from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 <div align="center">
   <h1>QRB ROS Camera</h1>
   <p align="center">
-   <img src="https://s7d1.scene7.com/is/image/dmqualcommprod/rb3gen2-dev-kits-hero-7" alt="Qualcomm QRB ROS" title="Qualcomm QRB ROS" />
       
   </p>
   <p>ROS Packages for Cameras on Qualcomm Robotics Platforms</p>
@@ -183,12 +182,10 @@ The `CamX` provides the foundation for image capture, processing, and management
 <table >
   <tr>
     <th>Development Hardware</th>
-    <td>Qualcomm Dragonwing™ RB3 Gen2</td>
     <td>Qualcomm Dragonwing™ IQ-9075 EVK</td>
   </tr>
   <tr>
     <th>Hardware Overview</th>
-    <th><a href="https://www.qualcomm.com/developer/hardware/rb3-gen-2-development-kit"><img src="https://s7d1.scene7.com/is/image/dmqualcommprod/rb3-gen2-carousel?fmt=webp-alpha&qlt=85" width="180"/></a></th>
     <th><a href="https://www.qualcomm.com/products/internet-of-things/industrial-processors/iq9-series/iq-9075"><img src="https://s7d1.scene7.com/is/image/dmqualcommprod/dragonwing-IQ-9075-EVK?$QC_Responsive$&fmt=png-alpha" width="160"></a></th>
   </tr>
   <tr>


### PR DESCRIPTION
## Summary
- Remove RB3 Gen2 references from the README, since RB3 Gen2 is no longer a supported target.

## Details
Removes RB3 Gen2 references from the README (supported-hardware table entry, and any RB3-specific banner image), keeping IQ-9075 EVK as the reference hardware. Documentation-only change.